### PR TITLE
converted channel on-off parameter from integer to boolean

### DIFF
--- a/source/psu/psu_utils.c
+++ b/source/psu/psu_utils.c
@@ -285,12 +285,12 @@ scpi_result_t SCPI_PsuOutState(scpi_t * context) {
         return SCPI_RES_ERR;
     }
     // read first parameter if present
-    int32_t param1;
-    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+    scpi_bool_t param1;
+    if (!SCPI_ParamBool(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
     }
     // set the output state by issuing a command to the PSU
-    do_outstate(chan, param1);
+    do_outstate(chan, param1 ? 1 : 0); // do_outstate expects int value 0 or 1
     return SCPI_RES_OK;
 }
 


### PR DESCRIPTION
close #1 

change `SOUR1:OUTP:STAT` parameter from number to bool

allows for:
```
:SOURCE1:OUTPUT:STATE ON|OFF
:SOURCE1:OUTPUT:STATE 1|0
```
Enables SCPI lib to throw an error when it's not one of these, without need if custom validation
The existing API function do_outstate() is unchanged. It will not see that this change in the SCPI syntax is made.
